### PR TITLE
Use async HTTP listener

### DIFF
--- a/Core/McpServer.cs
+++ b/Core/McpServer.cs
@@ -1,14 +1,14 @@
-﻿// McpServer.cs - Minimal HTTP listener (localhost only)
+// McpServer.cs - Minimal HTTP listener (async)
 using System;
 using System.Net;
 using System.Text;
-using System.Threading;
+using System.Threading.Tasks;
 using Autodesk.Revit.UI;
 
 public static class McpServer
 {
     private static HttpListener _listener;
-    private static Thread _thread;
+    private static Task _listenTask;
     private static ExternalEvent _externalEvent;
     private static RequestHandler _handler;
 
@@ -21,35 +21,69 @@ public static class McpServer
         _handler = new RequestHandler();
         _externalEvent = ExternalEvent.Create(_handler);
 
-        _thread = new Thread(ListenLoop);
-        _thread.Start();
+        _listenTask = ListenAsync();
     }
 
     public static void Stop()
     {
         _listener?.Stop();
-        _thread?.Join();
+        _listenTask?.Wait();
     }
 
-    private static void ListenLoop()
+    private static async Task ListenAsync()
     {
         while (_listener.IsListening)
         {
+            HttpListenerContext context = null;
             try
             {
-                var context = _listener.GetContext();
-                var reader = new System.IO.StreamReader(context.Request.InputStream);
-                string requestBody = reader.ReadToEnd();
-                reader.Close();
+                context = await _listener.GetContextAsync();
+            }
+            catch (HttpListenerException)
+            {
+                break;
+            }
+            catch (Exception ex)
+            {
+                LogError($"Accept error: {ex}");
+                continue;
+            }
 
-                _handler.SetRequest(requestBody, context);
-                try
-                {
-                    _externalEvent.Raise();
-                }
-                catch { }
+            _ = ProcessRequestAsync(context);
+        }
+    }
+
+    private static async Task ProcessRequestAsync(HttpListenerContext context)
+    {
+        try
+        {
+            using var reader = new System.IO.StreamReader(context.Request.InputStream);
+            string requestBody = await reader.ReadToEndAsync();
+
+            _handler.SetRequest(requestBody, context);
+            _externalEvent.Raise();
+        }
+        catch (Exception ex)
+        {
+            LogError($"Process error: {ex}");
+            try
+            {
+                context.Response.StatusCode = 500;
+                byte[] buffer = Encoding.UTF8.GetBytes("{\"status\":\"error\"}");
+                await context.Response.OutputStream.WriteAsync(buffer, 0, buffer.Length);
+                context.Response.Close();
             }
             catch { }
         }
+    }
+
+    private static void LogError(string message)
+    {
+        try
+        {
+            System.IO.File.AppendAllText("mcp.log",
+                $"{DateTime.Now:yyyy-MM-dd HH:mm:ss} {message}{Environment.NewLine}");
+        }
+        catch { }
     }
 }


### PR DESCRIPTION
## Summary
- replace thread-based listener with async loop
- log errors to file

## Testing
- `dotnet build IoB_revitMCP.sln -c Release` *(fails: reference assemblies for .NET Framework 4.8 not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850441b580c8330a8efb8a6b42e314b