### PR TITLE
Add built-in category parsing helper

### DIFF
--- a/Commands/AddViewFilterCommand.cs
+++ b/Commands/AddViewFilterCommand.cs
@@ -27,7 +27,7 @@ public class AddViewFilterCommand : ICommand
                 return response;
             }
 
-            var builtInCategory = (BuiltInCategory)Enum.Parse(typeof(BuiltInCategory), "OST_" + categoryName, true);
+            var builtInCategory = CategoryUtils.ParseBuiltInCategory(categoryName);
             var category = Category.GetCategory(doc, builtInCategory);
             if (category == null)
                 throw new Exception("Invalid category.");

--- a/Commands/ListElementsCommand.cs
+++ b/Commands/ListElementsCommand.cs
@@ -14,7 +14,7 @@ public class ListElementsCommand : ICommand
         string categoryName = input.ContainsKey("category") ? input["category"] : "Walls";
 
         var collector = new FilteredElementCollector(doc)
-            .OfCategory((BuiltInCategory)Enum.Parse(typeof(BuiltInCategory), "OST_" + categoryName, true))
+            .OfCategory(CategoryUtils.ParseBuiltInCategory(categoryName))
             .WhereElementIsNotElementType();
 
         var elements = collector.Select(e => new { Id = e.Id.IntegerValue, Name = e.Name }).ToList();

--- a/Helpers/CategoryUtils.cs
+++ b/Helpers/CategoryUtils.cs
@@ -1,0 +1,18 @@
+// CategoryUtils.cs - Helper utilities for categories
+using System;
+using Autodesk.Revit.DB;
+
+public static class CategoryUtils
+{
+    public static BuiltInCategory ParseBuiltInCategory(string name)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+            throw new ArgumentException("Category name cannot be null or empty", nameof(name));
+
+        if (!name.StartsWith("OST_", StringComparison.OrdinalIgnoreCase))
+            name = "OST_" + name;
+
+        return (BuiltInCategory)Enum.Parse(typeof(BuiltInCategory), name, true);
+    }
+}
+

--- a/Helpers/RevitHelpers.cs
+++ b/Helpers/RevitHelpers.cs
@@ -8,7 +8,7 @@ public static class RevitHelpers
 {
     public static List<Element> GetElementsByCategory(Document doc, string categoryName)
     {
-        var bic = (BuiltInCategory)Enum.Parse(typeof(BuiltInCategory), "OST_" + categoryName);
+        var bic = CategoryUtils.ParseBuiltInCategory(categoryName);
         return new FilteredElementCollector(doc)
             .OfCategory(bic)
             .WhereElementIsNotElementType()

--- a/IoB_revitMCP.csproj
+++ b/IoB_revitMCP.csproj
@@ -91,6 +91,7 @@
     <Compile Include="Commands\NewSharedParameter.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Helpers\RevitHelpers.cs" />
+    <Compile Include="Helpers\CategoryUtils.cs" />
     <Compile Include="Helpers\UiHelpers.cs" />
     <Compile Include="Commands\SetParameters.cs" />
   </ItemGroup>


### PR DESCRIPTION
## Summary
- add `CategoryUtils.ParseBuiltInCategory` helper
- use the helper in `ListElementsCommand`, `AddViewFilterCommand`, and `RevitHelpers`
- include new helper in project build

## Testing
- `dotnet build IoB_revitMCP.sln -c Release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685044387bd0833080345b73fa9c06cb