### PR TITLE
Add element type sync and schema

### DIFF
--- a/Commands/SyncModelToSqlCommand.cs
+++ b/Commands/SyncModelToSqlCommand.cs
@@ -3,7 +3,6 @@ using Autodesk.Revit.UI;
 using System;
 using System.Collections.Generic;
 using System.Configuration;
-using System.Linq;
 
 public class SyncModelToSqlCommand : ICommand
 {
@@ -33,7 +32,7 @@ public class SyncModelToSqlCommand : ICommand
         foreach (var element in collector)
         {
             string typeName = string.Empty;
-            Element type = doc.GetElement(element.GetTypeId());
+            ElementType type = doc.GetElement(element.GetTypeId()) as ElementType;
             if (type != null)
                 typeName = type.Name;
             string levelName = string.Empty;
@@ -44,13 +43,9 @@ public class SyncModelToSqlCommand : ICommand
             }
             db.UpsertElement(element.Id.IntegerValue, ParseGuid(element.UniqueId), element.Name, element.Category?.Name ?? string.Empty, typeName, levelName, doc.PathName, now);
 
-            foreach (Parameter param in element.Parameters)
+            if (type != null)
             {
-                if (param == null || param.Definition == null) continue;
-                string pname = param.Definition.Name;
-                string val = ParamToString(param);
-                bool isType = param.Element != null && param.Element.Id != element.Id;
-                db.UpsertParameter(element.Id.IntegerValue, pname, val, isType, null);
+                db.UpsertElementType(type.Id.IntegerValue, ParseGuid(type.UniqueId), type.FamilyName, type.Name, type.Category?.Name ?? string.Empty, doc.PathName, now);
             }
             count++;
         }
@@ -59,22 +54,6 @@ public class SyncModelToSqlCommand : ICommand
         return response;
     }
 
-    private static string ParamToString(Parameter p)
-    {
-        switch (p.StorageType)
-        {
-            case StorageType.String:
-                return p.AsString();
-            case StorageType.Double:
-                return p.AsDouble().ToString();
-            case StorageType.Integer:
-                return p.AsInteger().ToString();
-            case StorageType.ElementId:
-                return p.AsElementId().IntegerValue.ToString();
-            default:
-                return string.Empty;
-        }
-    }
 
     private static Guid ParseGuid(string uid)
     {

--- a/Data/PostgresDb.cs
+++ b/Data/PostgresDb.cs
@@ -201,4 +201,28 @@ public class PostgresDb
             new NpgsqlParameter("@guid", guid ?? (object)DBNull.Value),
             new NpgsqlParameter("@doc", docId ?? (object)DBNull.Value));
     }
+
+    public void UpsertElementType(int id, Guid guid, string family, string typeName,
+        string category, string docId, DateTime lastSeen)
+    {
+        string sql = @"INSERT INTO revit_elementTypes
+            (id, guid, family, type_name, category, doc_id, last_seen)
+            VALUES (@id, @guid, @family, @type_name, @category, @doc_id, @last_seen)
+            ON CONFLICT (id) DO UPDATE SET
+                guid = EXCLUDED.guid,
+                family = EXCLUDED.family,
+                type_name = EXCLUDED.type_name,
+                category = EXCLUDED.category,
+                doc_id = EXCLUDED.doc_id,
+                last_seen = EXCLUDED.last_seen";
+
+        ExecuteNonQuery(sql,
+            new NpgsqlParameter("@id", id),
+            new NpgsqlParameter("@guid", guid),
+            new NpgsqlParameter("@family", family ?? (object)DBNull.Value),
+            new NpgsqlParameter("@type_name", typeName ?? (object)DBNull.Value),
+            new NpgsqlParameter("@category", category ?? (object)DBNull.Value),
+            new NpgsqlParameter("@doc_id", docId ?? (object)DBNull.Value),
+            new NpgsqlParameter("@last_seen", lastSeen));
+    }
 }

--- a/postgres_schema.sql
+++ b/postgres_schema.sql
@@ -1,0 +1,87 @@
+-- Table: revit_elements
+CREATE TABLE IF NOT EXISTS revit_elements (
+    id INTEGER PRIMARY KEY,
+    guid UUID,
+    name TEXT,
+    category TEXT,
+    type_name TEXT,
+    level TEXT,
+    doc_id TEXT,
+    last_seen TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Table: revit_elementTypes
+CREATE TABLE IF NOT EXISTS revit_elementTypes (
+    id INTEGER PRIMARY KEY,
+    guid UUID,
+    family TEXT,
+    type_name TEXT,
+    category TEXT,
+    doc_id TEXT,
+    last_seen TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Table: revit_parameters
+CREATE TABLE IF NOT EXISTS revit_parameters (
+    id SERIAL PRIMARY KEY,
+    element_id INTEGER REFERENCES revit_elements(id) ON DELETE CASCADE,
+    param_name TEXT,
+    param_value TEXT,
+    is_type BOOLEAN,
+    applicable_categories TEXT[],
+    CONSTRAINT unique_element_param UNIQUE (element_id, param_name)
+);
+
+-- Table: revit_categories
+CREATE TABLE IF NOT EXISTS revit_categories (
+    id SERIAL PRIMARY KEY,
+    enum TEXT,
+    name TEXT,
+    category_group TEXT,
+    description TEXT,
+    guid UUID,
+    CONSTRAINT unique_category_enum UNIQUE (enum)
+);
+
+-- Table: revit_views
+CREATE TABLE IF NOT EXISTS revit_views (
+    id INTEGER PRIMARY KEY,
+    guid UUID,
+    name TEXT,
+    view_type TEXT,
+    scale INTEGER,
+    discipline TEXT,
+    detail_level TEXT,
+    associated_sheet_id INTEGER,
+    doc_id TEXT
+);
+
+-- Table: revit_sheets
+CREATE TABLE IF NOT EXISTS revit_sheets (
+    id INTEGER PRIMARY KEY,
+    guid UUID,
+    name TEXT,
+    number TEXT,
+    title_block TEXT,
+    doc_id TEXT
+);
+
+-- Table: revit_schedules
+CREATE TABLE IF NOT EXISTS revit_schedules (
+    id INTEGER PRIMARY KEY,
+    guid UUID,
+    name TEXT,
+    category TEXT,
+    doc_id TEXT
+);
+
+-- Table: revit_families
+CREATE TABLE IF NOT EXISTS revit_families (
+    id SERIAL PRIMARY KEY,
+    name TEXT,
+    family_type TEXT,
+    category TEXT,
+    guid UUID,
+    doc_id TEXT,
+    CONSTRAINT unique_family_name_type UNIQUE (name, family_type, category)
+);


### PR DESCRIPTION
## Summary
- update **SyncModelToSqlCommand** to only sync elements and store element types in a new table
- add `UpsertElementType` helper in PostgresDb
- create `postgres_schema.sql` with new `revit_elementTypes` table

------
https://chatgpt.com/codex/tasks/task_e_685cf6e2e9148330b8b2421cec28c44d