### PR TITLE
Fix UpsertFamily unique constraint

### DIFF
--- a/Data/PostgresDb.cs
+++ b/Data/PostgresDb.cs
@@ -190,9 +190,9 @@ public class PostgresDb
         string sql = @"INSERT INTO revit_families
             (name, family_type, category, guid, doc_id)
             VALUES (@name, @type, @cat, @guid, @doc)
-            ON CONFLICT (name, family_type, doc_id) DO UPDATE SET
-                category = EXCLUDED.category,
-                guid = EXCLUDED.guid";
+            ON CONFLICT (name, family_type, category) DO UPDATE SET
+                guid = EXCLUDED.guid,
+                doc_id = EXCLUDED.doc_id";
 
         ExecuteNonQuery(sql,
             new NpgsqlParameter("@name", name ?? (object)DBNull.Value),


### PR DESCRIPTION
## Summary
- correct `UpsertFamily` to use `(name, family_type, category)`
- update insert logic to update `guid` and `doc_id` on conflict

------
https://chatgpt.com/codex/tasks/task_e_685d2d7efb648330a8025b12422338d3