### PR TITLE
Add QuerySql command and update docs

### DIFF
--- a/Commands/QuerySqlCommand.cs
+++ b/Commands/QuerySqlCommand.cs
@@ -1,0 +1,64 @@
+using Autodesk.Revit.UI;
+using Newtonsoft.Json;
+using Npgsql;
+using System;
+using System.Collections.Generic;
+
+public class QuerySqlCommand : ICommand
+{
+    public Dictionary<string, object> Execute(UIApplication app, Dictionary<string, string> input)
+    {
+        var response = new Dictionary<string, object>();
+
+        try
+        {
+            string conn = DbConfigHelper.GetConnectionString(input);
+            if (string.IsNullOrEmpty(conn))
+            {
+                response["status"] = "error";
+                response["message"] = "No connection string found. " + DbConfigHelper.GetHelpMessage();
+                return response;
+            }
+
+            if (!input.TryGetValue("sql", out string sql) || string.IsNullOrWhiteSpace(sql))
+            {
+                response["status"] = "error";
+                response["message"] = "Missing 'sql' parameter.";
+                return response;
+            }
+
+            NpgsqlParameter[] parameters = null;
+            if (input.TryGetValue("params", out string paramJson) && !string.IsNullOrWhiteSpace(paramJson))
+            {
+                try
+                {
+                    var paramDict = JsonConvert.DeserializeObject<Dictionary<string, object>>(paramJson);
+                    var list = new List<NpgsqlParameter>();
+                    foreach (var kvp in paramDict)
+                    {
+                        list.Add(new NpgsqlParameter(kvp.Key, kvp.Value ?? DBNull.Value));
+                    }
+                    parameters = list.ToArray();
+                }
+                catch (Exception ex)
+                {
+                    response["status"] = "error";
+                    response["message"] = "Failed to parse params: " + ex.Message;
+                    return response;
+                }
+            }
+
+            var db = new PostgresDb(conn);
+            var results = db.Query(sql, parameters);
+            response["status"] = "success";
+            response["results"] = results;
+        }
+        catch (Exception ex)
+        {
+            response["status"] = "error";
+            response["message"] = ex.Message;
+        }
+
+        return response;
+    }
+}

--- a/Core/RequestHandler.cs
+++ b/Core/RequestHandler.cs
@@ -33,6 +33,7 @@ public class RequestHandler : IExternalEventHandler
         { "ListSheets", new ListSheetsCommand()},
         { "ListSchedules", new ListSchedulesCommand()},
         { "SyncModelToSql", new SyncModelToSqlCommand()},
+        { "QuerySql", new QuerySqlCommand()},
         { "GetModelContext", new GetModelContextCommand()},
         { "ExportToJson" , new ExportToJsonCommand() }
     };

--- a/IoB_revitMCP.csproj
+++ b/IoB_revitMCP.csproj
@@ -150,6 +150,7 @@
     <Compile Include="Commands\ListSheetsCommand.cs" />
     <Compile Include="Commands\ListSchedulesCommand.cs" />
     <Compile Include="Commands\SyncModelToSqlCommand.cs" />
+    <Compile Include="Commands\QuerySqlCommand.cs" />
     <Compile Include="Commands\GetModelContextCommand.cs" />
     <Compile Include="Commands\ModifyElementsCommand.cs" />
     <Compile Include="Commands\PlaceViewsOnSheet.cs" />

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ may return in the future.
 | `ListSheetsCommand.cs`         | Lists sheets and title blocks. |
 | `ListSchedulesCommand.cs`      | Lists schedule views in the model. |
 | `SyncModelToSqlCommand.cs`     | Writes model data to PostgreSQL. |
+| `QuerySqlCommand.cs`           | Executes arbitrary SQL queries against the PostgreSQL database. |
 
 | Helper Files                   | Purpose                                                                        |
 | ------------------------------ | ------------------------------------------------------------------------------ |
@@ -222,6 +223,34 @@ may return in the future.
 {
   "action": "SyncModelToSql"
 }
+```
+
+### 🔹 Run an Arbitrary SQL Query
+
+```json
+{
+  "action": "QuerySql",
+  "sql": "SELECT * FROM revit_elements WHERE category = @cat",
+  "params": "{ \"cat\": \"Walls\" }"
+}
+```
+
+## 🔌 Configuring the PostgreSQL Connection
+
+The plugin looks for a connection string in several locations:
+1. `App.config` under the key `revit`
+2. Environment variable `REVIT_DB_CONN`
+3. A file path provided via the `conn_file` parameter
+4. A `revit-conn.txt` file next to the add-in DLL
+
+Example `App.config` snippet:
+
+```xml
+<configuration>
+  <connectionStrings>
+    <add name="revit" connectionString="Host=localhost;Database=revit;Username=user;Password=pass"/>
+  </connectionStrings>
+</configuration>
 ```
 
 ---


### PR DESCRIPTION
## Summary
- implement `QuerySqlCommand` for executing arbitrary SQL queries through `PostgresDb`
- register the command in `RequestHandler.CommandMap`
- include the new command in the project file
- document database setup and provide example usage in README

------
https://chatgpt.com/codex/tasks/task_e_685d2d81b96883309006e6af3ac126ed