### PR TITLE
Add project metadata to model_info

### DIFF
--- a/Commands/GetModelContextCommand.cs
+++ b/Commands/GetModelContextCommand.cs
@@ -78,6 +78,7 @@ public class GetModelContextCommand : ICommand
 
             response["status"] = "success";
             response["model_name"] = doc.Title;
+            response["guid"] = ParseGuid(doc.ProjectInformation.UniqueId).ToString();
             response["last_saved"] = System.IO.File.GetLastWriteTime(doc.PathName).ToString("yyyy-MM-ddTHH:mm:ss");
             response["project_info"] = info;
             response["project_parameters"] = parameters;
@@ -89,5 +90,16 @@ public class GetModelContextCommand : ICommand
         }
 
         return response;
+    }
+
+    private static Guid ParseGuid(string uid)
+    {
+        if (string.IsNullOrEmpty(uid)) return Guid.Empty;
+        if (uid.Length >= 36)
+        {
+            Guid g;
+            if (Guid.TryParse(uid.Substring(0, 36), out g)) return g;
+        }
+        return Guid.Empty;
     }
 }

--- a/Commands/ListViewsCommand.cs
+++ b/Commands/ListViewsCommand.cs
@@ -29,6 +29,12 @@ public class ListViewsCommand : ICommand
             }
 
             PostgresDb db = new PostgresDb(conn);
+            DateTime lastSaved = System.IO.File.GetLastWriteTime(doc.PathName);
+            if (db.GetModelLastSaved(doc.PathName) == lastSaved)
+            {
+                response["status"] = "up_to_date";
+                return response;
+            }
 
             var views = new FilteredElementCollector(doc)
                 .OfClass(typeof(View))
@@ -55,8 +61,9 @@ public class ListViewsCommand : ICommand
                 result.Add(item);
 
                 int? sheetId = vp != null ? (int?)vp.SheetId.IntegerValue : null;
-                db.UpsertView(view.Id.IntegerValue, Guid.Empty, view.Name, view.ViewType.ToString(), view.Scale, discipline, view.DetailLevel.ToString(), sheetId, doc.PathName);
+                db.UpsertView(view.Id.IntegerValue, Guid.Empty, view.Name, view.ViewType.ToString(), view.Scale, discipline, view.DetailLevel.ToString(), sheetId, doc.PathName, lastSaved);
             }
+            db.UpsertModelInfo(doc.PathName, doc.Title, ParseGuid(doc.ProjectInformation.UniqueId), lastSaved);
             response["status"] = "success";
             response["views"] = result;
         }
@@ -66,5 +73,16 @@ public class ListViewsCommand : ICommand
             response["message"] = ex.Message;
         }
         return response;
+    }
+
+    private static Guid ParseGuid(string uid)
+    {
+        if (string.IsNullOrEmpty(uid)) return Guid.Empty;
+        if (uid.Length >= 36)
+        {
+            Guid g;
+            if (Guid.TryParse(uid.Substring(0, 36), out g)) return g;
+        }
+        return Guid.Empty;
     }
 }

--- a/Commands/SyncModelToSqlCommand.cs
+++ b/Commands/SyncModelToSqlCommand.cs
@@ -3,6 +3,7 @@ using Autodesk.Revit.UI;
 using System;
 using System.Collections.Generic;
 using System.Configuration;
+using System.Text.Json;
 
 public class SyncModelToSqlCommand : ICommand
 {
@@ -43,14 +44,71 @@ public class SyncModelToSqlCommand : ICommand
 
         // Proceed as usual if the test passed
         var db = new PostgresDb(conn);
-        DateTime now = DateTime.UtcNow;
+        DateTime lastSaved = System.IO.File.GetLastWriteTime(doc.PathName);
+        if (db.GetModelLastSaved(doc.PathName) == lastSaved)
+        {
+            response["status"] = "up_to_date";
+            return response;
+        }
+
+        // capture model info and parameters
+        var projectInfo = doc.ProjectInformation;
+        var info = new Dictionary<string, string>();
+        foreach (Parameter p in projectInfo.Parameters)
+        {
+            if (p == null || string.IsNullOrEmpty(p.Definition?.Name)) continue;
+            string val = string.Empty;
+            switch (p.StorageType)
+            {
+                case StorageType.String:
+                    val = p.AsString();
+                    break;
+                case StorageType.Integer:
+                    val = p.AsInteger().ToString();
+                    break;
+                case StorageType.Double:
+                    val = p.AsDouble().ToString();
+                    break;
+                case StorageType.ElementId:
+                    val = p.AsElementId().IntegerValue.ToString();
+                    break;
+            }
+            info[p.Definition.Name] = val;
+        }
+
+        var bindingMap = doc.ParameterBindings;
+        var iterator = bindingMap.ForwardIterator();
+        var parameters = new List<Dictionary<string, object>>();
+        iterator.Reset();
+        while (iterator.MoveNext())
+        {
+            Definition definition = iterator.Key;
+            ElementBinding binding = iterator.Current as ElementBinding;
+            if (definition == null || binding == null) continue;
+            var paramData = new Dictionary<string, object>();
+            paramData["name"] = definition.Name;
+            paramData["parameter_type"] = definition.ParameterGroup.ToString();
+            paramData["unit_type_id"] = definition.GetDataType()?.TypeId?.ToString() ?? string.Empty;
+            paramData["binding_type"] = binding is InstanceBinding ? "Instance" : "Type";
+            var categories = new List<string>();
+            foreach (Category cat in binding.Categories)
+            {
+                if (cat != null) categories.Add(cat.Name);
+            }
+            paramData["categories"] = categories;
+            parameters.Add(paramData);
+        }
+
+        string jsonInfo = JsonSerializer.Serialize(info);
+        string jsonParams = JsonSerializer.Serialize(parameters);
+        db.UpsertModelInfo(doc.PathName, doc.Title, ParseGuid(doc.ProjectInformation.UniqueId), lastSaved, jsonInfo, jsonParams);
 
         // gather element types once and store in DB
         var typeCollector = new FilteredElementCollector(doc).WhereElementIsElementType();
         var typeMap = new Dictionary<ElementId, string>();
         foreach (ElementType type in typeCollector)
         {
-            db.UpsertElementType(type.Id.IntegerValue, ParseGuid(type.UniqueId), type.FamilyName, type.Name, type.Category?.Name ?? string.Empty, doc.PathName, now);
+            db.UpsertElementType(type.Id.IntegerValue, ParseGuid(type.UniqueId), type.FamilyName, type.Name, type.Category?.Name ?? string.Empty, doc.PathName, lastSaved);
             if (!typeMap.ContainsKey(type.Id))
                 typeMap[type.Id] = type.Name;
         }
@@ -69,11 +127,16 @@ public class SyncModelToSqlCommand : ICommand
                 var lvl = doc.GetElement(element.LevelId);
                 if (lvl != null) levelName = lvl.Name;
             }
-            db.UpsertElement(element.Id.IntegerValue, ParseGuid(element.UniqueId), element.Name, element.Category?.Name ?? string.Empty, typeName, levelName, doc.PathName, now);
+            db.UpsertElement(element.Id.IntegerValue, ParseGuid(element.UniqueId), element.Name, element.Category?.Name ?? string.Empty, typeName, levelName, doc.PathName, lastSaved);
             count++;
         }
         response["status"] = "success";
         response["updated"] = count;
+        response["model_name"] = doc.Title;
+        response["project_info"] = info;
+        response["project_parameters"] = parameters;
+        response["guid"] = ParseGuid(doc.ProjectInformation.UniqueId).ToString();
+        response["last_saved"] = lastSaved.ToString("yyyy-MM-ddTHH:mm:ss");
         return response;
     }
 

--- a/Data/PostgresDb.cs
+++ b/Data/PostgresDb.cs
@@ -98,31 +98,33 @@ public class PostgresDb
             new NpgsqlParameter("@categories", applicable ?? (object)DBNull.Value));
     }
 
-    public void UpsertCategory(string enumVal, string name, string group, string description, Guid guid)
+    public void UpsertCategory(string enumVal, string name, string group, string description, Guid guid, DateTime lastSaved)
     {
         string sql = @"INSERT INTO revit_categories
-            (enum, name, category_group, description, guid)
-            VALUES (@enum, @name, @group, @description, @guid)
+            (enum, name, category_group, description, guid, last_saved)
+            VALUES (@enum, @name, @group, @description, @guid, @last_saved)
             ON CONFLICT (enum) DO UPDATE SET
                 name = EXCLUDED.name,
                 category_group = EXCLUDED.category_group,
                 description = EXCLUDED.description,
-                guid = EXCLUDED.guid";
+                guid = EXCLUDED.guid,
+                last_saved = EXCLUDED.last_saved";
 
         ExecuteNonQuery(sql,
             new NpgsqlParameter("@enum", enumVal),
             new NpgsqlParameter("@name", name ?? (object)DBNull.Value),
             new NpgsqlParameter("@group", group ?? (object)DBNull.Value),
             new NpgsqlParameter("@description", description ?? (object)DBNull.Value),
-            new NpgsqlParameter("@guid", guid));
+            new NpgsqlParameter("@guid", guid),
+            new NpgsqlParameter("@last_saved", lastSaved));
     }
 
     public void UpsertView(int id, Guid guid, string name, string viewType, int scale,
-        string discipline, string detail, int? sheetId, string docId)
+        string discipline, string detail, int? sheetId, string docId, DateTime lastSaved)
     {
         string sql = @"INSERT INTO revit_views
-            (id, guid, name, view_type, scale, discipline, detail_level, associated_sheet_id, doc_id)
-            VALUES (@id, @guid, @name, @type, @scale, @disc, @detail, @sheet, @doc)
+            (id, guid, name, view_type, scale, discipline, detail_level, associated_sheet_id, doc_id, last_saved)
+            VALUES (@id, @guid, @name, @type, @scale, @disc, @detail, @sheet, @doc, @last_saved)
             ON CONFLICT (id) DO UPDATE SET
                 guid = EXCLUDED.guid,
                 name = EXCLUDED.name,
@@ -131,7 +133,8 @@ public class PostgresDb
                 discipline = EXCLUDED.discipline,
                 detail_level = EXCLUDED.detail_level,
                 associated_sheet_id = EXCLUDED.associated_sheet_id,
-                doc_id = EXCLUDED.doc_id";
+                doc_id = EXCLUDED.doc_id,
+                last_saved = EXCLUDED.last_saved";
 
         ExecuteNonQuery(sql,
             new NpgsqlParameter("@id", id),
@@ -142,20 +145,22 @@ public class PostgresDb
             new NpgsqlParameter("@disc", discipline ?? (object)DBNull.Value),
             new NpgsqlParameter("@detail", detail ?? (object)DBNull.Value),
             new NpgsqlParameter("@sheet", sheetId ?? (object)DBNull.Value),
-            new NpgsqlParameter("@doc", docId ?? (object)DBNull.Value));
+            new NpgsqlParameter("@doc", docId ?? (object)DBNull.Value),
+            new NpgsqlParameter("@last_saved", lastSaved));
     }
 
-    public void UpsertSheet(int id, Guid guid, string name, string number, string titleBlock, string docId)
+    public void UpsertSheet(int id, Guid guid, string name, string number, string titleBlock, string docId, DateTime lastSaved)
     {
         string sql = @"INSERT INTO revit_sheets
-            (id, guid, name, number, title_block, doc_id)
-            VALUES (@id, @guid, @name, @num, @tb, @doc)
+            (id, guid, name, number, title_block, doc_id, last_saved)
+            VALUES (@id, @guid, @name, @num, @tb, @doc, @last_saved)
             ON CONFLICT (id) DO UPDATE SET
                 guid = EXCLUDED.guid,
                 name = EXCLUDED.name,
                 number = EXCLUDED.number,
                 title_block = EXCLUDED.title_block,
-                doc_id = EXCLUDED.doc_id";
+                doc_id = EXCLUDED.doc_id,
+                last_saved = EXCLUDED.last_saved";
 
         ExecuteNonQuery(sql,
             new NpgsqlParameter("@id", id),
@@ -163,43 +168,48 @@ public class PostgresDb
             new NpgsqlParameter("@name", name ?? (object)DBNull.Value),
             new NpgsqlParameter("@num", number ?? (object)DBNull.Value),
             new NpgsqlParameter("@tb", titleBlock ?? (object)DBNull.Value),
-            new NpgsqlParameter("@doc", docId ?? (object)DBNull.Value));
+            new NpgsqlParameter("@doc", docId ?? (object)DBNull.Value),
+            new NpgsqlParameter("@last_saved", lastSaved));
     }
 
-    public void UpsertSchedule(int id, Guid guid, string name, string category, string docId)
+    public void UpsertSchedule(int id, Guid guid, string name, string category, string docId, DateTime lastSaved)
     {
         string sql = @"INSERT INTO revit_schedules
-            (id, guid, name, category, doc_id)
-            VALUES (@id, @guid, @name, @cat, @doc)
+            (id, guid, name, category, doc_id, last_saved)
+            VALUES (@id, @guid, @name, @cat, @doc, @last_saved)
             ON CONFLICT (id) DO UPDATE SET
                 guid = EXCLUDED.guid,
                 name = EXCLUDED.name,
                 category = EXCLUDED.category,
-                doc_id = EXCLUDED.doc_id";
+                doc_id = EXCLUDED.doc_id,
+                last_saved = EXCLUDED.last_saved";
 
         ExecuteNonQuery(sql,
             new NpgsqlParameter("@id", id),
             new NpgsqlParameter("@guid", guid),
             new NpgsqlParameter("@name", name ?? (object)DBNull.Value),
             new NpgsqlParameter("@cat", category ?? (object)DBNull.Value),
-            new NpgsqlParameter("@doc", docId ?? (object)DBNull.Value));
+            new NpgsqlParameter("@doc", docId ?? (object)DBNull.Value),
+            new NpgsqlParameter("@last_saved", lastSaved));
     }
 
-    public void UpsertFamily(string name, string familyType, string category, string guid, string docId)
+    public void UpsertFamily(string name, string familyType, string category, string guid, string docId, DateTime lastSaved)
     {
         string sql = @"INSERT INTO revit_families
-            (name, family_type, category, guid, doc_id)
-            VALUES (@name, @type, @cat, @guid, @doc)
+            (name, family_type, category, guid, doc_id, last_saved)
+            VALUES (@name, @type, @cat, @guid, @doc, @last_saved)
             ON CONFLICT (name, family_type, category) DO UPDATE SET
                 guid = EXCLUDED.guid,
-                doc_id = EXCLUDED.doc_id";
+                doc_id = EXCLUDED.doc_id,
+                last_saved = EXCLUDED.last_saved";
 
         ExecuteNonQuery(sql,
             new NpgsqlParameter("@name", name ?? (object)DBNull.Value),
             new NpgsqlParameter("@type", familyType ?? (object)DBNull.Value),
             new NpgsqlParameter("@cat", category ?? (object)DBNull.Value),
             new NpgsqlParameter("@guid", guid ?? (object)DBNull.Value),
-            new NpgsqlParameter("@doc", docId ?? (object)DBNull.Value));
+            new NpgsqlParameter("@doc", docId ?? (object)DBNull.Value),
+            new NpgsqlParameter("@last_saved", lastSaved));
     }
 
     public void UpsertElementType(int id, Guid guid, string family, string typeName,
@@ -224,5 +234,34 @@ public class PostgresDb
             new NpgsqlParameter("@category", category ?? (object)DBNull.Value),
             new NpgsqlParameter("@doc_id", docId ?? (object)DBNull.Value),
             new NpgsqlParameter("@last_seen", lastSeen));
+    }
+
+    public void UpsertModelInfo(string docId, string modelName, Guid guid, DateTime lastSaved, string projectInfo = null, string projectParameters = null)
+    {
+        string sql = @"INSERT INTO model_info
+            (doc_id, model_name, guid, last_saved, project_info, project_parameters)
+            VALUES (@doc, @name, @guid, @last_saved, @info, @params)
+            ON CONFLICT (doc_id) DO UPDATE SET
+                model_name = EXCLUDED.model_name,
+                guid = EXCLUDED.guid,
+                last_saved = EXCLUDED.last_saved,
+                project_info = EXCLUDED.project_info,
+                project_parameters = EXCLUDED.project_parameters";
+
+        ExecuteNonQuery(sql,
+            new NpgsqlParameter("@doc", docId ?? (object)DBNull.Value),
+            new NpgsqlParameter("@name", modelName ?? (object)DBNull.Value),
+            new NpgsqlParameter("@guid", guid),
+            new NpgsqlParameter("@last_saved", lastSaved),
+            new NpgsqlParameter("@info", projectInfo ?? (object)DBNull.Value),
+            new NpgsqlParameter("@params", projectParameters ?? (object)DBNull.Value));
+    }
+
+    public DateTime? GetModelLastSaved(string docId)
+    {
+        var rows = Query("SELECT last_saved FROM model_info WHERE doc_id = @doc", new NpgsqlParameter("@doc", docId));
+        if (rows.Count > 0 && rows[0].ContainsKey("last_saved") && rows[0]["last_saved"] is DateTime dt)
+            return dt;
+        return null;
     }
 }

--- a/postgres_schema.sql
+++ b/postgres_schema.sql
@@ -10,6 +10,16 @@ CREATE TABLE IF NOT EXISTS revit_elements (
     last_seen TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
 
+-- Table: model_info
+CREATE TABLE IF NOT EXISTS model_info (
+    doc_id TEXT PRIMARY KEY,
+    model_name TEXT,
+    guid UUID,
+    last_saved TIMESTAMP,
+    project_info JSONB,
+    project_parameters JSONB
+);
+
 -- Table: revit_elementTypes
 CREATE TABLE IF NOT EXISTS revit_elementTypes (
     id INTEGER PRIMARY KEY,
@@ -40,6 +50,7 @@ CREATE TABLE IF NOT EXISTS revit_categories (
     category_group TEXT,
     description TEXT,
     guid UUID,
+    last_saved TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     CONSTRAINT unique_category_enum UNIQUE (enum)
 );
 
@@ -53,7 +64,8 @@ CREATE TABLE IF NOT EXISTS revit_views (
     discipline TEXT,
     detail_level TEXT,
     associated_sheet_id INTEGER,
-    doc_id TEXT
+    doc_id TEXT,
+    last_saved TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
 
 -- Table: revit_sheets
@@ -63,7 +75,8 @@ CREATE TABLE IF NOT EXISTS revit_sheets (
     name TEXT,
     number TEXT,
     title_block TEXT,
-    doc_id TEXT
+    doc_id TEXT,
+    last_saved TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
 
 -- Table: revit_schedules
@@ -72,7 +85,8 @@ CREATE TABLE IF NOT EXISTS revit_schedules (
     guid UUID,
     name TEXT,
     category TEXT,
-    doc_id TEXT
+    doc_id TEXT,
+    last_saved TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
 
 -- Table: revit_families
@@ -83,5 +97,6 @@ CREATE TABLE IF NOT EXISTS revit_families (
     category TEXT,
     guid UUID,
     doc_id TEXT,
+    last_saved TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     CONSTRAINT unique_family_name_type UNIQUE (name, family_type, category)
 );


### PR DESCRIPTION
## Summary
- expand `model_info` table with `project_info` and `project_parameters`
- store project metadata when syncing model to SQL
- include model metadata in `SyncModelToSql` responses

## Testing
- `dotnet build IoB_revitMCP.csproj -nologo` *(fails: command not found)*
- `msbuild IoB_revitMCP.csproj /nologo` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e4c440ec08330ae3503a863d280c1