### PR TITLE
Ensure list commands sync SQL & add parameter timestamp

### DIFF
--- a/Commands/ListElementsCommand.cs
+++ b/Commands/ListElementsCommand.cs
@@ -13,13 +13,60 @@ public class ListElementsCommand : ICommand
         var response = new Dictionary<string, object>();
         string categoryName = input.ContainsKey("category") ? input["category"] : "Walls";
 
+        string conn = DbConfigHelper.GetConnectionString(input);
+        PostgresDb db = null;
+        if (!string.IsNullOrEmpty(conn))
+            db = new PostgresDb(conn);
+
+        DateTime lastSaved = System.IO.File.GetLastWriteTime(doc.PathName);
+
         var collector = new FilteredElementCollector(doc)
             .OfCategory(CategoryUtils.ParseBuiltInCategory(categoryName))
             .WhereElementIsNotElementType();
 
-        var elements = collector.Select(e => new { Id = e.Id.IntegerValue, Name = e.Name }).ToList();
+        var elements = new List<Dictionary<string, object>>();
+        foreach (var e in collector)
+        {
+            var item = new Dictionary<string, object>();
+            item["id"] = e.Id.IntegerValue;
+            item["name"] = e.Name;
+            item["doc_id"] = doc.PathName;
+            elements.Add(item);
+
+            if (db != null)
+            {
+                string typeName = string.Empty;
+                var et = doc.GetElement(e.GetTypeId()) as ElementType;
+                if (et != null) typeName = et.Name;
+
+                string levelName = string.Empty;
+                if (e is Element el && el.LevelId != ElementId.InvalidElementId)
+                {
+                    var lvl = doc.GetElement(el.LevelId);
+                    if (lvl != null) levelName = lvl.Name;
+                }
+
+                db.UpsertElement(e.Id.IntegerValue, ParseGuid(e.UniqueId), e.Name,
+                    e.Category?.Name ?? string.Empty, typeName, levelName, doc.PathName, lastSaved);
+            }
+        }
+
+        if (db != null)
+            db.UpsertModelInfo(doc.PathName, doc.Title, ParseGuid(doc.ProjectInformation.UniqueId), lastSaved);
+
         response["status"] = "success";
         response["elements"] = elements;
         return response;
+    }
+
+    private static Guid ParseGuid(string uid)
+    {
+        if (string.IsNullOrEmpty(uid)) return Guid.Empty;
+        if (uid.Length >= 36)
+        {
+            Guid g;
+            if (Guid.TryParse(uid.Substring(0, 36), out g)) return g;
+        }
+        return Guid.Empty;
     }
 }

--- a/Data/PostgresDb.cs
+++ b/Data/PostgresDb.cs
@@ -81,22 +81,24 @@ public class PostgresDb
     }
 
     public void UpsertParameter(int elementId, string name, string value, bool isType,
-        string[] applicable)
+        string[] applicable, DateTime lastSaved)
     {
         string sql = @"INSERT INTO revit_parameters
-            (element_id, param_name, param_value, is_type, applicable_categories)
-            VALUES (@elid, @name, @value, @is_type, @categories)
+            (element_id, param_name, param_value, is_type, applicable_categories, last_saved)
+            VALUES (@elid, @name, @value, @is_type, @categories, @last_saved)
             ON CONFLICT (element_id, param_name) DO UPDATE SET
                 param_value = EXCLUDED.param_value,
                 is_type = EXCLUDED.is_type,
-                applicable_categories = EXCLUDED.applicable_categories";
+                applicable_categories = EXCLUDED.applicable_categories,
+                last_saved = EXCLUDED.last_saved";
 
         ExecuteNonQuery(sql,
             new NpgsqlParameter("@elid", elementId),
             new NpgsqlParameter("@name", name),
             new NpgsqlParameter("@value", value ?? (object)DBNull.Value),
             new NpgsqlParameter("@is_type", isType),
-            new NpgsqlParameter("@categories", applicable ?? (object)DBNull.Value));
+            new NpgsqlParameter("@categories", applicable ?? (object)DBNull.Value),
+            new NpgsqlParameter("@last_saved", lastSaved));
     }
 
     public void UpsertCategory(string enumVal, string name, string group, string description, Guid guid, DateTime lastSaved)

--- a/postgres_schema.sql
+++ b/postgres_schema.sql
@@ -39,6 +39,7 @@ CREATE TABLE IF NOT EXISTS revit_parameters (
     param_value TEXT,
     is_type BOOLEAN,
     applicable_categories TEXT[],
+    last_saved TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     CONSTRAINT unique_element_param UNIQUE (element_id, param_name)
 );
 


### PR DESCRIPTION
## Summary
- add `last_saved` column to `revit_parameters`
- include `last_saved` in `PostgresDb.UpsertParameter`
- sync parameter export without relying on Revit selection
- upsert elements in `ListElementsCommand`
- update model context command to optionally persist model info

## Testing
- `dotnet build IoB_revitMCP.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862342932f4833098f76a5b429196cc