### PR TITLE
Use consistent last_saved naming

### DIFF
--- a/Commands/ListElementParametersCommand.cs
+++ b/Commands/ListElementParametersCommand.cs
@@ -76,7 +76,7 @@ public class ListElementParametersCommand : ICommand
                     typeName,
                     levelName,
                     doc.PathName,
-                    now);
+                    lastSaved);
             }
 
             var paramData = new Dictionary<string, object>();

--- a/Data/PostgresDb.cs
+++ b/Data/PostgresDb.cs
@@ -55,11 +55,11 @@ public class PostgresDb
     }
 
     public void UpsertElement(int id, Guid guid, string name, string category,
-        string typeName, string level, string docId, DateTime lastSeen)
+        string typeName, string level, string docId, DateTime lastSaved)
     {
         string sql = @"INSERT INTO revit_elements
-            (id, guid, name, category, type_name, level, doc_id, last_seen)
-            VALUES (@id, @guid, @name, @category, @type_name, @level, @doc_id, @last_seen)
+            (id, guid, name, category, type_name, level, doc_id, last_saved)
+            VALUES (@id, @guid, @name, @category, @type_name, @level, @doc_id, @last_saved)
             ON CONFLICT (id) DO UPDATE SET
                 guid = EXCLUDED.guid,
                 name = EXCLUDED.name,
@@ -67,8 +67,8 @@ public class PostgresDb
                 type_name = EXCLUDED.type_name,
                 level = EXCLUDED.level,
                 doc_id = EXCLUDED.doc_id,
-                last_seen = EXCLUDED.last_seen
-            WHERE EXCLUDED.last_seen > revit_elements.last_seen";
+                last_saved = EXCLUDED.last_saved
+            WHERE EXCLUDED.last_saved > revit_elements.last_saved";
 
         ExecuteNonQuery(sql,
             new NpgsqlParameter("@id", id),
@@ -78,7 +78,7 @@ public class PostgresDb
             new NpgsqlParameter("@type_name", typeName ?? (object)DBNull.Value),
             new NpgsqlParameter("@level", level ?? (object)DBNull.Value),
             new NpgsqlParameter("@doc_id", docId ?? (object)DBNull.Value),
-            new NpgsqlParameter("@last_seen", lastSeen));
+            new NpgsqlParameter("@last_saved", lastSaved));
     }
 
     public void UpsertParameter(int elementId, string name, string value, bool isType,
@@ -223,19 +223,19 @@ public class PostgresDb
     }
 
     public void UpsertElementType(int id, Guid guid, string family, string typeName,
-        string category, string docId, DateTime lastSeen)
+        string category, string docId, DateTime lastSaved)
     {
         string sql = @"INSERT INTO revit_elementTypes
-            (id, guid, family, type_name, category, doc_id, last_seen)
-            VALUES (@id, @guid, @family, @type_name, @category, @doc_id, @last_seen)
+            (id, guid, family, type_name, category, doc_id, last_saved)
+            VALUES (@id, @guid, @family, @type_name, @category, @doc_id, @last_saved)
             ON CONFLICT (id) DO UPDATE SET
                 guid = EXCLUDED.guid,
                 family = EXCLUDED.family,
                 type_name = EXCLUDED.type_name,
                 category = EXCLUDED.category,
                 doc_id = EXCLUDED.doc_id,
-                last_seen = EXCLUDED.last_seen
-            WHERE EXCLUDED.last_seen > revit_elementTypes.last_seen";
+                last_saved = EXCLUDED.last_saved
+            WHERE EXCLUDED.last_saved > revit_elementTypes.last_saved";
 
         ExecuteNonQuery(sql,
             new NpgsqlParameter("@id", id),
@@ -244,7 +244,7 @@ public class PostgresDb
             new NpgsqlParameter("@type_name", typeName ?? (object)DBNull.Value),
             new NpgsqlParameter("@category", category ?? (object)DBNull.Value),
             new NpgsqlParameter("@doc_id", docId ?? (object)DBNull.Value),
-            new NpgsqlParameter("@last_seen", lastSeen));
+            new NpgsqlParameter("@last_saved", lastSaved));
     }
 
     public void UpsertModelInfo(string docId, string modelName, Guid guid, DateTime lastSaved, string projectInfo = null, string projectParameters = null)

--- a/TASKS_postgres.md
+++ b/TASKS_postgres.md
@@ -13,7 +13,7 @@
   - Accepts optional `element_ids` to limit export.
   - Gathers element metadata (id, guid, name, category, type name, level, doc id).
   - Writes/updates records in `revit_elements` and `revit_parameters` via `PostgresDb`.
-  - Removes DB records whose `last_seen` is older than current session for that document.
+  - Removes DB records whose `last_saved` is older than current session for that document.
   - Returns counts of inserted/updated/deleted records.
 - **ListCategoriesCommand.cs**
   - Enumerates all categories, populates `revit_categories` table.

--- a/agenPromptExtraShort.md
+++ b/agenPromptExtraShort.md
@@ -35,9 +35,9 @@ Remove the OST_ prefix from category names when querying.
 
 |Table         |Columns                                                           |
 |--------------|------------------------------------------------------------------|
-|revit_elements|id, guid, name, category, type_name, level, doc_id, last_seen     |
+|revit_elements|id, guid, name, category, type_name, level, doc_id, last_saved     |
 |model_info    |doc_id, model_name, guid, last_saved, project_info, project_parameters|
-|revit_elementtypes|id, guid, family, type_name, category, doc_id, last_seen|
+|revit_elementtypes|id, guid, family, type_name, category, doc_id, last_saved|
 |revit_parameters|id, element_id, param_name, param_value, is_type, applicable_categories|
 |revit_categories|id, enum, name, category_group, description, guid, last_saved|
 |revit_views|id, guid, name, view_type, scale, discipline, detail_level, associated_sheet_id, doc_id, last_saved|

--- a/agentPrompt_short.md
+++ b/agentPrompt_short.md
@@ -64,9 +64,9 @@ Remove the OST_ prefix from category names when querying.
 
 |Table          | Columns                                                           |
 |---------------|------------------------------------------------------------------|
-|revit_elements | id, guid, name, category, type_name, level, doc_id, last_seen     |
+|revit_elements | id, guid, name, category, type_name, level, doc_id, last_saved     |
 |model_info    | doc_id, model_name, guid, last_saved, project_info, project_parameters|
-|revit_elementtypes | id, guid, family, type_name, category, doc_id, last_seen|
+|revit_elementtypes | id, guid, family, type_name, category, doc_id, last_saved|
 |revit_parameters | id, element_id, param_name, param_value, is_type, applicable_categories|
 |revit_categories | id, enum, name, category_group, description, guid, last_saved|
 |revit_views | id, guid, name, view_type, scale, discipline, detail_level, associated_sheet_id, doc_id, last_saved|

--- a/postgres_schema.sql
+++ b/postgres_schema.sql
@@ -7,7 +7,7 @@ CREATE TABLE IF NOT EXISTS revit_elements (
     type_name TEXT,
     level TEXT,
     doc_id TEXT,
-    last_seen TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+    last_saved TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
 
 -- Table: model_info
@@ -28,7 +28,7 @@ CREATE TABLE IF NOT EXISTS revit_elementTypes (
     type_name TEXT,
     category TEXT,
     doc_id TEXT,
-    last_seen TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+    last_saved TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
 
 -- Table: revit_parameters


### PR DESCRIPTION
## Summary
- standardize `last_saved` naming across database helpers and docs
- sync schema to new field name

------
https://chatgpt.com/codex/tasks/task_e_68623e6c3bdc8330ba07c76136a33c41