### PR TITLE
Improve performance with caching and async queue

### DIFF
--- a/Commands/EnqueuePlanCommand.cs
+++ b/Commands/EnqueuePlanCommand.cs
@@ -1,0 +1,28 @@
+using Autodesk.Revit.UI;
+using Newtonsoft.Json;
+using System.Collections.Generic;
+
+/// <summary>
+/// Inserts a plan into the mcp_queue table for asynchronous execution.
+/// Returns the generated job id.
+/// </summary>
+public class EnqueuePlanCommand : ICommand
+{
+    public Dictionary<string, object> Execute(UIApplication app, Dictionary<string, string> input)
+    {
+        var response = new Dictionary<string, object>();
+        string conn = DbConfigHelper.GetConnectionString(input);
+        if (string.IsNullOrEmpty(conn) || !input.TryGetValue("plan", out var plan))
+        {
+            response["status"] = "error";
+            response["message"] = "Missing connection string or plan";
+            return response;
+        }
+
+        var db = new PostgresDb(conn);
+        int id = db.EnqueuePlan(plan);
+        response["status"] = "queued";
+        response["job_id"] = id;
+        return response;
+    }
+}

--- a/Commands/PlanExecutorCommand.cs
+++ b/Commands/PlanExecutorCommand.cs
@@ -16,6 +16,16 @@ public class PlanExecutorCommand : ICommand
         var doc = app.ActiveUIDocument.Document;
         var results = new List<object>();
 
+        string conn = DbConfigHelper.GetConnectionString(input);
+        if (input.TryGetValue("async", out var asyncFlag) && asyncFlag == "true" && !string.IsNullOrEmpty(conn))
+        {
+            var db = new PostgresDb(conn);
+            int id = db.EnqueuePlan(input["steps"]);
+            response["status"] = "queued";
+            response["job_id"] = id;
+            return response;
+        }
+
         try
         {
             if (!input.ContainsKey("steps"))

--- a/Core/App.cs
+++ b/Core/App.cs
@@ -21,6 +21,7 @@ public class App : IExternalApplication
     public Result OnShutdown(UIControlledApplication app)
     {
         McpServer.Stop();
+        QueueProcessor.Stop();
         return Result.Succeeded;
     }
 }

--- a/Core/QueueProcessor.cs
+++ b/Core/QueueProcessor.cs
@@ -1,0 +1,73 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Autodesk.Revit.UI;
+using Newtonsoft.Json;
+
+/// <summary>
+/// Background worker that executes queued plans from the mcp_queue table.
+/// </summary>
+public static class QueueProcessor
+{
+    private static CancellationTokenSource _cts;
+    private static Task _task;
+    private static UIApplication _uiApp;
+    private static bool _started;
+
+    public static void Start(UIApplication app)
+    {
+        if (_started) return;
+        _uiApp = app;
+        _cts = new CancellationTokenSource();
+        _task = Task.Run(() => ProcessLoop(_cts.Token));
+        _started = true;
+    }
+
+    public static void Stop()
+    {
+        if (_cts != null)
+        {
+            _cts.Cancel();
+            _task?.Wait(1000);
+            _cts.Dispose();
+        }
+        _started = false;
+    }
+
+    private static void ProcessLoop(CancellationToken token)
+    {
+        string conn = System.Configuration.ConfigurationManager.ConnectionStrings["mcp"]?.ConnectionString;
+        if (string.IsNullOrEmpty(conn)) return;
+        var db = new PostgresDb(conn);
+        var planCmd = new PlanExecutorCommand();
+        while (!token.IsCancellationRequested)
+        {
+            try
+            {
+                var (id, plan) = db.DequeuePlan();
+                if (id == 0)
+                {
+                    Task.Delay(1000, token).Wait(token);
+                    continue;
+                }
+
+                var input = new Dictionary<string, string>
+                {
+                    {"steps", plan }
+                };
+                var result = planCmd.Execute(_uiApp, input);
+                string jsonResult = JsonConvert.SerializeObject(result);
+                db.SetJobResult(id, "done", jsonResult);
+            }
+            catch (OperationCanceledException)
+            {
+                break;
+            }
+            catch
+            {
+                // swallow and continue
+            }
+        }
+    }
+}

--- a/Core/RequestHandler.cs
+++ b/Core/RequestHandler.cs
@@ -35,7 +35,8 @@ public class RequestHandler : IExternalEventHandler
         { "NewSharedParameter", new NewSharedParameterCommand() },
         { "PlaceViewsOnSheet", new PlaceViewsOnSheetCommand() },
         { "QuerySql", new QuerySqlCommand()},
-        { "SyncModelToSql", new SyncModelToSqlCommand()}
+        { "SyncModelToSql", new SyncModelToSqlCommand()},
+        { "EnqueuePlan", new EnqueuePlanCommand() }
     };
 
     public void SetRequest(string body, HttpListenerContext context)
@@ -45,6 +46,7 @@ public class RequestHandler : IExternalEventHandler
 
     public void Execute(UIApplication app)
     {
+        QueueProcessor.Start(app);
         while (_requests.TryDequeue(out var req))
         {
             var requestBody = req.body;

--- a/Helpers/ModelCache.cs
+++ b/Helpers/ModelCache.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Collections.Concurrent;
+
+/// <summary>
+/// Simple in-memory cache keyed by document path and last saved timestamp.
+/// Cached values expire automatically when model's last_saved changes.
+/// </summary>
+public static class ModelCache
+{
+    private static readonly ConcurrentDictionary<string, (DateTime saved, object data)> _cache
+        = new ConcurrentDictionary<string, (DateTime, object)>();
+
+    public static bool TryGet<T>(string docPath, DateTime lastSaved, out T value)
+    {
+        value = default(T);
+        if (_cache.TryGetValue(docPath, out var entry) && entry.saved == lastSaved && entry.data is T t)
+        {
+            value = t;
+            return true;
+        }
+        return false;
+    }
+
+    public static void Set(string docPath, DateTime lastSaved, object value)
+    {
+        _cache[docPath] = (lastSaved, value);
+    }
+}

--- a/IoB_revitMCP.csproj
+++ b/IoB_revitMCP.csproj
@@ -163,11 +163,14 @@
     <Compile Include="Commands\PlanExecutorCommand.cs" />
     <Compile Include="Core\RequestHandler.cs" />
     <Compile Include="Commands\NewSharedParameter.cs" />
+    <Compile Include="Commands\EnqueuePlanCommand.cs" />
     <Compile Include="Helpers\DbConfigHelper.cs" />
+    <Compile Include="Helpers\ModelCache.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Helpers\RevitHelpers.cs" />
     <Compile Include="Helpers\CategoryUtils.cs" />
     <Compile Include="Helpers\UiHelpers.cs" />
+    <Compile Include="Core\QueueProcessor.cs" />
     <Compile Include="Data\PostgresDb.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ future.
 * **Vector Search Tools** – resolve category names or API concepts with `RevitBuiltinCategories` and `RevitApiVectorDB`.
 * **Plan Execution** – chain multiple commands in a single request.
 * **LLM Integration** – use the provided n8n workflow to translate chat messages into commands.
+* **Async Queue** – long-running plans can be queued via `EnqueuePlan` and executed in the background.
+* **In-memory Caching** – frequently used metadata like views and parameter bindings are cached per model session.
 
 ---
 
@@ -262,6 +264,18 @@ future.
   "params": "{ \"cat\": \"Walls\" }"
 }
 ```
+
+### 🔹 Queue a Plan for Async Execution
+
+```json
+{
+  "action": "EnqueuePlan",
+  "plan": "[{ \"action\": \"ListElements\", \"params\":{\"category\":\"Walls\"}}]",
+  "conn_file": "revit-conn.txt"
+}
+```
+
+Queued plans run in the background and results are stored in the `mcp_queue` table.
 
 ## 🔌 Configuring the PostgreSQL Connection
 

--- a/postgres_schema.sql
+++ b/postgres_schema.sql
@@ -101,3 +101,13 @@ CREATE TABLE IF NOT EXISTS revit_families (
     last_saved TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     CONSTRAINT unique_family_name_type UNIQUE (name, family_type, category)
 );
+
+-- Table: mcp_queue
+CREATE TABLE IF NOT EXISTS mcp_queue (
+    id SERIAL PRIMARY KEY,
+    plan JSONB,
+    status TEXT DEFAULT 'pending',
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    completed_at TIMESTAMP,
+    result JSONB
+);


### PR DESCRIPTION
## Summary
- add `ModelCache` helper
- cache expensive data in `ListViews` and `ListElementParameters`
- allow `PlanExecutor` to enqueue plans when `async` flag is set
- implement background `QueueProcessor` and new `EnqueuePlan` command
- add queue schema and supporting DB helpers
- document asynchronous queue usage

## Testing
- `apt-get update -y`
- `apt-get install -y mono-devel`
- `xbuild IoB_revitMCP.sln` *(fails: missing NuGet packages)*

------
https://chatgpt.com/codex/tasks/task_e_6862a2e7caf08330b25f08199735eb22