### PR TITLE
Add command examples to agent prompts

### DIFF
--- a/agenPromptExtraShort.md
+++ b/agenPromptExtraShort.md
@@ -96,4 +96,12 @@ Executes commands in Revit.
 { "action": "PlaceViewsOnSheet", "sheet_id": 111, "view_ids": "101,102" }
 { "action": "AddViewFilter", "category": "Walls", "filter_name": "ColoredExternalWalls", "parameter": "Top is Attached", "value": "No", "visible": "true", "color": "255,0,0",  "line_pattern": "Dashed", "fill_color": "255,255,0", "fill_pattern": "Solid Fill" }
 { "action": "ListModelContext" }
+{ "action": "ListCategories" }
+{ "action": "ListFamiliesAndTypes" }
+{ "action": "ListSheets" }
+{ "action": "ListSchedules" }
+{ "action": "ListViews" }
+{ "action": "QuerySql", "sql": "SELECT * FROM revit_elements WHERE category = @cat", "params": "{ \"cat\": \"Walls\" }" }
+{ "action": "SyncModelToSql" }
+{ "action": "EnqueuePlan", "plan": "[{ \"action\": \"ListElementsByCategory\", \"params\":{\"category\":\"Walls\"}}]", "conn_file": "revit-conn.txt" }
 ```

--- a/agentPrompt_short.md
+++ b/agentPrompt_short.md
@@ -169,3 +169,63 @@ Use to send the structured commands defined below.
   "fill_color": "255,255,0",
   "fill_pattern": "Solid Fill" }
 ```
+
+**ListCategories** – list all categories.
+
+```json
+{ "action": "ListCategories" }
+```
+
+**ListElementsByCategory** – retrieve all elements of a category.
+
+```json
+{ "action": "ListElementsByCategory", "category": "Walls" }
+```
+
+**ListFamiliesAndTypes** – list families and their types.
+
+```json
+{ "action": "ListFamiliesAndTypes" }
+```
+
+**ListModelContext** – get model metadata.
+
+```json
+{ "action": "ListModelContext" }
+```
+
+**ListViews** – list all views.
+
+```json
+{ "action": "ListViews" }
+```
+
+**ListSheets** – list all sheets.
+
+```json
+{ "action": "ListSheets" }
+```
+
+**ListSchedules** – list all schedules.
+
+```json
+{ "action": "ListSchedules" }
+```
+
+**QuerySql** – run custom SQL against synced data.
+
+```json
+{ "action": "QuerySql", "sql": "SELECT * FROM revit_elements WHERE category = @cat", "params": "{ \"cat\": \"Walls\" }" }
+```
+
+**SyncModelToSql** – export model data to PostgreSQL.
+
+```json
+{ "action": "SyncModelToSql" }
+```
+
+**EnqueuePlan** – queue a plan for asynchronous execution.
+
+```json
+{ "action": "EnqueuePlan", "plan": "[{ \"action\": \"ListElementsByCategory\", \"params\":{\"category\":\"Walls\"}}]", "conn_file": "revit-conn.txt" }
+```


### PR DESCRIPTION
## Summary
- expand `agentPrompt_short.md` with JSON examples for every command
- update `agenPromptExtraShort.md` with the same full list of examples

------
https://chatgpt.com/codex/tasks/task_e_6863a530f8a48330a3791724708517a4