### PR TITLE
Add parameter filter option

### DIFF
--- a/Commands/ListElementParametersCommand.cs
+++ b/Commands/ListElementParametersCommand.cs
@@ -69,6 +69,11 @@ public class ListElementParametersCommand : ICommand
 
         var result = new Dictionary<string, object>();
         var paramNames = new HashSet<string>();
+        HashSet<string> filterNames = null;
+        if (input.TryGetValue("param_names", out var namesStr) && !string.IsNullOrWhiteSpace(namesStr))
+        {
+            filterNames = new HashSet<string>(namesStr.Split(',').Select(s => s.Trim()), StringComparer.OrdinalIgnoreCase);
+        }
         DateTime now = DateTime.UtcNow;
         foreach (var id in ids)
         {
@@ -109,6 +114,7 @@ public class ListElementParametersCommand : ICommand
                 if (param == null) continue;
                 string name = param.Definition?.Name;
                 if (string.IsNullOrEmpty(name)) continue;
+                if (filterNames != null && !filterNames.Contains(name)) continue;
                 paramNames.Add(name);
                 string storage = param.StorageType.ToString();
                 object value = null;

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ future.
 | **ExportToJson**           | `action` with optional `categories` list (defaults to Walls)\               | –                                                                         | `elements` (instance and type in their respective tables) array with id, name, category and parameter values\                             |
 | **FilterByParameter**      | `action`, `param`, `value`, `input_elements` (JSON list)\                   | –                                                                         | `elements` list containing `{ Id, Name }` of matching elements\                                                                           |
 | **ListCategories**         | `action` plus a PostgreSQL connection string (via config/env/`conn_file`)\  | –                                                                         | `categories` list describing each Revit category\                                                                                         |
-| **ListElementParameters**  | `action` plus `element_ids` (comma list) or selected elements\              | connection string options via `conn_file` etc.                            | `parameters` keyed by element id and `parameter_names` list\                                                                              |
+| **ListElementParameters**  | `action` plus `element_ids` (comma list) or selected elements\              | `param_names` comma list, connection string options via `conn_file` etc.                            | `parameters` keyed by element id and `parameter_names` list\                                                                              |
 | **ListElementsByCategory** | `action` (name `ListElementsByCategory`), `category` (defaults to Walls)\   | –                                                                         | `elements` list with id and name\                                                                                                         |
 | **ListFamiliesAndTypes**   | `action` (`GetFamilyAndTypes`)                                              | `class_name` to filter, optional database connection                      | Returns `types` list with family, type, id, category, guid, doc_id,info\                                                                  |
 | **ListSchedules**          | `action` and DB connection string\                                          | –                                                                         | `schedules` list with id, name and category\                                                                                              |
@@ -97,7 +97,8 @@ future.
 ```json
 {
   "action": "ListElementParameters",
-  "element_ids": "123456,789012"
+  "element_ids": "123456,789012",
+  "param_names": "Mark,Comments"
 }
 ```
 

--- a/agenPromptExtraShort.md
+++ b/agenPromptExtraShort.md
@@ -71,7 +71,7 @@ Executes commands in Revit.
 | `ExportToJson`           | Export selected categories to JSON. |
 | `FilterByParameter`      | Filter element list by a parameter's value. |
 | `ListCategories`         | List all Revit categories. |
-| `ListElementParameters`  | Retrieve parameters for specified elements. |
+| `ListElementParameters`  | Retrieve parameters for specified elements (optional `param_names`). |
 | `ListElementsByCategory` | List all elements of a specified category. |
 | `ListFamiliesAndTypes`   | Retrieve all families and their types in the model. |
 | `ListModelContext`       | Return active model name, path, and project info. |
@@ -91,7 +91,7 @@ Executes commands in Revit.
 { "action": "ListElementsByCategory", "category": "Walls" }
 { "action": "FilterByParameter", "param": "FireRating", "value": "120", "input_elements": [...] }
 { "action": "ListElementParameters" }
-{ "action": "ListElementParameters", "element_ids": "123,456" }
+{ "action": "ListElementParameters", "element_ids": "123,456", "param_names": "Mark,Comments" }
 { "action": "ModifyElements", "changes": [ { "element_id": 123, "parameters": { "Mark": "Wall-A" } } ] }
 { "action": "NewSharedParameter", "parameter_name": "...", "categories": "Walls" }
 { "action": "ModifyElements", "changes": [ { "element_id": 200, "new_type_name": "New Type" } ] }

--- a/agentPrompt_short.md
+++ b/agentPrompt_short.md
@@ -105,7 +105,7 @@ Use to send the structured commands defined below.
 | `FilterByParameter`      | Filter element list by a parameter's value. |
 | `ListCategories`         | List all Revit categories. |
 | `ListElementsByCategory` | List all elements of a specified category. |
-| `ListElementParameters`  | Retrieve parameters for specified elements. |
+| `ListElementParameters`  | Retrieve parameters for specified elements (optional `param_names`). |
 | `ListFamiliesAndTypes`   | Retrieve all families and their types in the model. |
 | `ListModelContext`       | Return active model name, path, and project info. |
 | `ListSheets`             | List all Revit sheets. |
@@ -133,7 +133,7 @@ Use to send the structured commands defined below.
 
 ```json
 { "action": "ListElementParameters" }
-{ "action": "ListElementParameters", "element_ids": "123,456" }
+{ "action": "ListElementParameters", "element_ids": "123,456", "param_names": "Mark,Comments" }
 ```
 
 **ModifyElements** – update parameter values.

--- a/agentPrompts.md
+++ b/agentPrompts.md
@@ -350,6 +350,7 @@ Retrieve parameters for specified elements or the current selection.
 **Inputs**:
 
 - `element_ids` (optional, string): comma-separated list of element IDs. If omitted, uses the current selection.
+- `param_names` (optional, string): comma-separated list of parameter names to include.
 
 **Expected Output**:
 
@@ -359,7 +360,7 @@ Retrieve parameters for specified elements or the current selection.
 **Usage Example**:
 
 ```json
-{ "action": "ListElementParameters", "element_ids": "123,456" }
+{ "action": "ListElementParameters", "element_ids": "123,456", "param_names": "Mark,Comments" }
 ```
 
 **Typical Use Case for AI Agent**:


### PR DESCRIPTION
## Summary
- add optional `param_names` input for `ListElementParameters`
- skip unlisted parameters when supplied
- document `param_names` usage in README and agent prompts

------
https://chatgpt.com/codex/tasks/task_e_686500392d688330ae94d5ec27f4ab5c