### PR TITLE
Implement caching for listing elements and families

### DIFF
--- a/Commands/ListElementsCommand.cs
+++ b/Commands/ListElementsCommand.cs
@@ -20,6 +20,14 @@ public class ListElementsCommand : ICommand
 
         DateTime lastSaved = System.IO.File.GetLastWriteTime(doc.PathName);
 
+        if (ModelCache.TryGet(doc.PathName + "/elements-" + categoryName, lastSaved,
+                out List<Dictionary<string, object>> cached))
+        {
+            response["status"] = "success";
+            response["elements"] = cached;
+            return response;
+        }
+
         var collector = new FilteredElementCollector(doc)
             .OfCategory(CategoryUtils.ParseBuiltInCategory(categoryName))
             .WhereElementIsNotElementType();
@@ -54,6 +62,7 @@ public class ListElementsCommand : ICommand
         if (db != null)
             db.UpsertModelInfo(doc.PathName, doc.Title, ParseGuid(doc.ProjectInformation.UniqueId), lastSaved);
 
+        ModelCache.Set(doc.PathName + "/elements-" + categoryName, lastSaved, elements);
         response["status"] = "success";
         response["elements"] = elements;
         return response;

--- a/Commands/ListFamiliesAndTypesCommand.cs
+++ b/Commands/ListFamiliesAndTypesCommand.cs
@@ -49,6 +49,14 @@ public class ListFamiliesAndTypesCommand : ICommand
                 }
             }
 
+            string cacheKey = doc.PathName + "/families-" + filterType.Name;
+            if (ModelCache.TryGet(cacheKey, lastSaved, out List<Dictionary<string, object>> cached))
+            {
+                response["status"] = "success";
+                response["types"] = cached;
+                return response;
+            }
+
             var types = new FilteredElementCollector(doc)
                 .WhereElementIsElementType()
                 .OfClass(filterType)
@@ -77,6 +85,7 @@ public class ListFamiliesAndTypesCommand : ICommand
             if (db != null)
                 db.UpsertModelInfo(doc.PathName, doc.Title, ParseGuid(doc.ProjectInformation.UniqueId), lastSaved);
 
+            ModelCache.Set(cacheKey, lastSaved, result);
             response["status"] = "success";
             response["types"] = result;
         }


### PR DESCRIPTION
## Summary
- speed up listing elements and families by caching results in `ModelCache`
- use keys containing category/type name so cached data is reused across calls

------
https://chatgpt.com/codex/tasks/task_e_6865003941808330b924c9e1840ab77b