### PR TITLE
Fix build issues

### DIFF
--- a/RevitExtractor/RevitExtractor.csproj
+++ b/RevitExtractor/RevitExtractor.csproj
@@ -32,6 +32,7 @@
     <Reference Include="System" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Data" />
     <Reference Include="RevitAPI">
       <HintPath>C:\Program Files\Autodesk\Revit 2023\RevitAPI.dll</HintPath>
       <Private>False</Private>


### PR DESCRIPTION
## Summary
- avoid variable name collision in `SyncModelToSqlCommand`
- explicitly use `System.Text.Json.JsonSerializer`
- reference `System.Data` in `RevitExtractor`

## Testing
- ❌ `dotnet restore IoB_revitMCP.sln` *(fails: command not found)*
- ❌ `msbuild /version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865119282c4833083a1a3d8385f053c