### PR TITLE
Add CaptureToolState command and update prompts

### DIFF
--- a/Commands/CaptureToolStateCommand.cs
+++ b/Commands/CaptureToolStateCommand.cs
@@ -1,0 +1,78 @@
+using Autodesk.Revit.DB;
+using Autodesk.Revit.UI;
+using Autodesk.Revit.UI.Selection;
+using System;
+using System.Collections.Generic;
+
+public class CaptureToolStateCommand : ICommand
+{
+    public Dictionary<string, object> Execute(UIApplication app, Dictionary<string, string> input)
+    {
+        var response = new Dictionary<string, object>();
+        var uidoc = app.ActiveUIDocument;
+        var doc = uidoc?.Document;
+
+        if (doc == null)
+        {
+            response["status"] = "error";
+            response["message"] = "No active document.";
+            return response;
+        }
+
+        try
+        {
+            var state = new Dictionary<string, object>();
+            state["document_name"] = doc.Title;
+
+            var view = doc.ActiveView;
+            var activeView = new Dictionary<string, object>
+            {
+                ["name"] = view.Name,
+                ["id"] = view.Id.IntegerValue,
+                ["type"] = view.ViewType.ToString()
+            };
+            state["active_view"] = activeView;
+
+            var selected = new List<Dictionary<string, object>>();
+            foreach (ElementId id in uidoc.Selection.GetElementIds())
+            {
+                var el = doc.GetElement(id);
+                if (el == null) continue;
+
+                var item = new Dictionary<string, object>();
+                item["id"] = el.Id.IntegerValue;
+                item["category"] = el.Category?.Name ?? string.Empty;
+                item["type_name"] = doc.GetElement(el.GetTypeId())?.Name ?? string.Empty;
+
+                var paramDict = new Dictionary<string, string>();
+                foreach (Parameter p in el.Parameters)
+                {
+                    if (p.Definition?.Name == null) continue;
+                    string val = p.StorageType switch
+                    {
+                        StorageType.String => p.AsString(),
+                        StorageType.Integer => p.AsInteger().ToString(),
+                        StorageType.Double => p.AsDouble().ToString(),
+                        StorageType.ElementId => p.AsElementId().IntegerValue.ToString(),
+                        _ => string.Empty
+                    };
+                    paramDict[p.Definition.Name] = val ?? string.Empty;
+                }
+                item["parameters"] = paramDict;
+
+                selected.Add(item);
+            }
+            state["selected_elements"] = selected;
+
+            response["status"] = "success";
+            response["tool_state"] = state;
+        }
+        catch (Exception ex)
+        {
+            response["status"] = "error";
+            response["message"] = ex.Message;
+        }
+
+        return response;
+    }
+}

--- a/Core/RequestHandler.cs
+++ b/Core/RequestHandler.cs
@@ -32,6 +32,7 @@ public class RequestHandler : IExternalEventHandler
         { "ListSchedules", new ListSchedulesCommand()},
         { "ListSheets", new ListSheetsCommand()},
         { "ListViews", new ListViewsCommand()},
+        { "CaptureToolState", new CaptureToolStateCommand()},
         { "ModifyElements", new ModifyElementsCommand() },
         { "NewSharedParameter", new NewSharedParameterCommand() },
         { "PlaceViewsOnSheet", new PlaceViewsOnSheetCommand() },
@@ -76,6 +77,7 @@ public class RequestHandler : IExternalEventHandler
                 scope.SetVariable("ShowTaskDialog", new Action<string, string>(UiHelpers.ShowTaskDialog));
                 scope.SetVariable("get_elements", new Func<Document, string, List<Element>>(RevitHelpers.GetElementsByCategory));
                 scope.SetVariable("set_parameter", new Action<Element, string, string>(RevitHelpers.SetParameter));
+                scope.SetVariable("capture_tool_state", new Func<UIDocument, Dictionary<string, object>>(RevitHelpers.CaptureToolState));
 
                 string script = request.ContainsKey("script") ? request["script"] : "print('No script provided')";
 

--- a/Helpers/RevitHelpers.cs
+++ b/Helpers/RevitHelpers.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Autodesk.Revit.DB;
+using Autodesk.Revit.UI;
 
 public static class RevitHelpers
 {
@@ -23,5 +24,56 @@ public static class RevitHelpers
         {
             param.Set(value);
         }
+    }
+
+    public static Dictionary<string, object> CaptureToolState(UIDocument uidoc)
+    {
+        var doc = uidoc?.Document;
+        if (doc == null) return null;
+
+        var state = new Dictionary<string, object>();
+        state["document_name"] = doc.Title;
+
+        var view = doc.ActiveView;
+        state["active_view"] = new Dictionary<string, object>
+        {
+            ["name"] = view.Name,
+            ["id"] = view.Id.IntegerValue,
+            ["type"] = view.ViewType.ToString()
+        };
+
+        var selected = new List<Dictionary<string, object>>();
+        foreach (var id in uidoc.Selection.GetElementIds())
+        {
+            var el = doc.GetElement(id);
+            if (el == null) continue;
+
+            var item = new Dictionary<string, object>
+            {
+                ["id"] = el.Id.IntegerValue,
+                ["category"] = el.Category?.Name ?? string.Empty,
+                ["type_name"] = doc.GetElement(el.GetTypeId())?.Name ?? string.Empty
+            };
+
+            var paramDict = new Dictionary<string, string>();
+            foreach (Parameter p in el.Parameters)
+            {
+                if (p.Definition?.Name == null) continue;
+                string val = p.StorageType switch
+                {
+                    StorageType.String => p.AsString(),
+                    StorageType.Integer => p.AsInteger().ToString(),
+                    StorageType.Double => p.AsDouble().ToString(),
+                    StorageType.ElementId => p.AsElementId().IntegerValue.ToString(),
+                    _ => string.Empty
+                };
+                paramDict[p.Definition.Name] = val ?? string.Empty;
+            }
+            item["parameters"] = paramDict;
+            selected.Add(item);
+        }
+
+        state["selected_elements"] = selected;
+        return state;
     }
 }

--- a/IoB_revitMCP.csproj
+++ b/IoB_revitMCP.csproj
@@ -150,6 +150,7 @@
     <Compile Include="Commands\ListViewsCommand.cs" />
     <Compile Include="Commands\ListSheetsCommand.cs" />
     <Compile Include="Commands\ListSchedulesCommand.cs" />
+    <Compile Include="Commands\CaptureToolStateCommand.cs" />
     <Compile Include="Commands\SyncModelToSqlCommand.cs" />
     <Compile Include="Commands\QuerySqlCommand.cs" />
     <Compile Include="Commands\ListModelContextCommand.cs" />

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ future.
 | `ListSheets`             | List all Revit sheets.                                                  |
 | `ListSchedules`          | List all schedules in the model.                                        |
 | `ListViews`              | List all Revit views.                                                   |
+| `CaptureToolState`       | Inspect active view and selection.                     |
 | `ModifyElements`         | Update types and/or parameters for elements.                            |
 | `NewSharedParameter`     | Create and bind a shared parameter to categories.                       |
 | `PlaceViewsOnSheet`      | Place view(s) on a sheet with layout options.                           |
@@ -83,6 +84,10 @@ future.
 | **ListSchedules**          | `action` and DB connection string\                                          | –                                                                         | `schedules` list with id, name and category\                                                                                              |
 | **ListModelContext**       | `action` only                                                               | –                                                                         | Returns model metadata including `model_name`, `guid`, `last_saved`, and lists of project parameters\                                     |
 | **ListViews**              | `action` and DB connection string\                                          | –                                                                         | `views` list with metadata including scale and associated sheet id\                                                                       |
+| **CaptureToolState**       | `action`
+                           | –
+                       | `tool_state` object describing active view and selected elements\
+   |
 | **ListSheets**             | `action` and DB connection string\                                          | –                                                                         | `sheets` list with name, number and title block                                                                                           |
 | **ModifyElements**         | `action`, `changes` (JSON array)\                                           | –                                                                         | `status`, per-element results with `type_changed`, `updated_parameters`, `skipped_parameters`                                             |
 | **NewSharedParameter**     | `action`, `parameter_name`, `parameter_group`, `categories`, `binding_type` | –                                                                         | `parameter`, `categories` on success or error details\                                                                                    |

--- a/agenPromptExtraShort.md
+++ b/agenPromptExtraShort.md
@@ -14,6 +14,7 @@ You are an expert assistant for a Revit MCP Plugin. You translate user requests 
   2. Fetch the relevant element or type IDs.
   3. Upsert their parameters into the table.
   4. Retrieve or modify the updated parameters as needed.
+  5. You now have access to a new tool called `CaptureToolState` for inspecting the active view and selected elements.
 
 # Toolset Summary
 
@@ -75,6 +76,7 @@ Executes commands in Revit.
 | `ListElementsByCategory` | List all elements of a specified category. |
 | `ListFamiliesAndTypes`   | Retrieve all families and their types in the model. |
 | `ListModelContext`       | Return active model name, path, and project info. |
+| `CaptureToolState`       | Serialize the active view and selected element info. |
 | `ListSheets`             | List all Revit sheets. |
 | `ListSchedules`          | List all schedules in the model. |
 | `ListViews`              | List all Revit views. |
@@ -101,6 +103,7 @@ Executes commands in Revit.
 { "action": "ListModelContext" }
 { "action": "ListCategories" }
 { "action": "ListFamiliesAndTypes" }
+{ "action": "CaptureToolState" }
 { "action": "ListSheets" }
 { "action": "ListSchedules" }
 { "action": "ListViews" }

--- a/agentPrompt_short.md
+++ b/agentPrompt_short.md
@@ -14,6 +14,7 @@ You are an expert assistant for a Revit MCP Plugin. You translate user requests 
   2. Retrieve the relevant element or type IDs.
   3. Upsert their parameter data into the database.
   4. Then retrieve or modify those parameters as needed.
+  5. You now have access to a new tool called `CaptureToolState` for inspecting the active view and selected elements.
 
 # Tools
 
@@ -108,6 +109,7 @@ Use to send the structured commands defined below.
 | `ListElementParameters`  | Retrieve parameters for specified elements (optional `param_names`). |
 | `ListFamiliesAndTypes`   | Retrieve all families and their types in the model. |
 | `ListModelContext`       | Return active model name, path, and project info. |
+| `CaptureToolState`       | Serialize the active view and selected element info. |
 | `ListSheets`             | List all Revit sheets. |
 | `ListSchedules`          | List all schedules in the model. |
 | `ListViews`              | List all Revit views. |
@@ -195,6 +197,12 @@ Use to send the structured commands defined below.
 
 ```json
 { "action": "ListModelContext" }
+```
+
+**CaptureToolState** – inspect the current UI context.
+
+```json
+{ "action": "CaptureToolState" }
 ```
 
 **ListViews** – list all views.

--- a/agentPrompts.md
+++ b/agentPrompts.md
@@ -14,6 +14,7 @@ You are a helpful and knowledgable AI assistant, specializes in Revit MCP Plugin
   2. Retrieve the corresponding element or type IDs.
   3. Upsert their parameters into the database.
   4. Retrieve or modify the updated parameter values as required.
+  5. You now have access to a new tool called `CaptureToolState` for inspecting the active view and selected elements.
 
 # Tools
 
@@ -52,6 +53,7 @@ Use this tool to send structured JSON data to interact with Revit model with bel
 - [ListFamiliesAndTypes](#command-listfamiliesandtypes)
 - [ListModelContext](#command-listmodelcontext)
 - [ListViews](#command-listviews)
+- [CaptureToolState](#command-capturetoolstate)
 - [ListSheets](#command-listsheets)
 - [ListSchedules](#command-listschedules)
 - [ModifyElements](#command-modifyelements)
@@ -550,6 +552,31 @@ A JSON object with:
 - Monitor changes in `Project Information` and trigger additional scans or plan executions if differences are detected.
 
 - Cache model metadata to improve performance and reduce redundant scanning in repeated agent runs.
+
+---
+
+### Command: CaptureToolState
+
+**Purpose**:
+Serializes the current Revit UI state, including active view info and selected elements with parameters.
+
+**Inputs**:
+None required.
+
+**Expected Output**:
+- `status`: "success" or "error"
+- `tool_state`: object with `document_name`, `active_view`, and `selected_elements` data.
+
+**Usage Example**:
+
+```json
+{
+  "action": "CaptureToolState"
+}
+```
+
+**Typical Use Case for AI Agent**:
+Use this tool to inspect what the user is currently viewing or working on before making suggestions or chaining other tools.
 
 ---
 


### PR DESCRIPTION
## Summary
- implement `CaptureToolStateCommand` for inspecting active view and selection
- expose helper `CaptureToolState` for IronPython scripts
- register new command in request handler and project file
- document tool in README and agent prompt files

------
https://chatgpt.com/codex/tasks/task_e_68677cc805a08330a92e587efdcab8c8